### PR TITLE
Adjust composition lines order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ music_school_jaume_tor/__pycache__/__init__.cpython-312.pyc
 music_school_jaume_tor/models/__pycache__/__init__.cpython-312.pyc
 music_school_jaume_tor/models/__pycache__/music_school_instrument.cpython-312.pyc
 music_school_jaume_tor/models/__pycache__/music_school_student.cpython-312.pyc
+product_composition/__pycache__/__init__.cpython-312.pyc
+product_composition/__pycache__/__manifest__.cpython-312.pyc
+product_composition/models/__pycache__/__init__.cpython-312.pyc
+product_composition/models/__pycache__/product_composition_line.cpython-312.pyc
+product_composition/models/__pycache__/product_template.cpython-312.pyc

--- a/product_composition/__init__.py
+++ b/product_composition/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/product_composition/__manifest__.py
+++ b/product_composition/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    'name': 'Product Composition',
+    'version': '18.0.1.0.0',
+    'summary': 'Manage product compositions',
+    'description': 'Manage the composition of products with percentage and description.',
+    'category': 'Product',
+    'author': 'Codex',
+    'license': 'LGPL-3',
+    'depends': ['product'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/product_composition_description_views.xml',
+        'views/product_composition_menu.xml',
+        'views/product_composition_views.xml',
+    ],
+    'installable': True,
+}

--- a/product_composition/models/__init__.py
+++ b/product_composition/models/__init__.py
@@ -1,0 +1,3 @@
+from . import product_composition_line
+from . import product_template
+from . import product_composition_description

--- a/product_composition/models/product_composition_description.py
+++ b/product_composition/models/product_composition_description.py
@@ -1,0 +1,9 @@
+from odoo import models, fields
+
+
+class ProductCompositionDescription(models.Model):
+    _name = 'product.composition.description'
+    _description = 'Product Composition Description'
+
+    name = fields.Char(required=True)
+

--- a/product_composition/models/product_composition_line.py
+++ b/product_composition/models/product_composition_line.py
@@ -1,0 +1,20 @@
+from odoo import models, fields
+
+
+class ProductCompositionLine(models.Model):
+    _name = 'product.composition.line'
+    _description = 'Product Composition Line'
+
+    product_tmpl_id = fields.Many2one(
+        comodel_name='product.template',
+        string='Product',
+        required=True,
+        ondelete='cascade'
+    )
+    percentage = fields.Float(string='Percentage')
+    description_id = fields.Many2one(
+        comodel_name='product.composition.description',
+        string='Description',
+        required=True,
+        ondelete='restrict',
+    )

--- a/product_composition/models/product_template.py
+++ b/product_composition/models/product_template.py
@@ -1,0 +1,11 @@
+from odoo import models, fields
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    composition_line_ids = fields.One2many(
+        comodel_name='product.composition.line',
+        inverse_name='product_tmpl_id',
+        string='Compositions'
+    )

--- a/product_composition/security/ir.model.access.csv
+++ b/product_composition/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_product_composition_line_user,product.composition.line,model_product_composition_line,base.group_user,1,1,1,1
+access_product_composition_description_user,product.composition.description,model_product_composition_description,base.group_user,1,1,1,1

--- a/product_composition/views/product_composition_description_views.xml
+++ b/product_composition/views/product_composition_description_views.xml
@@ -1,0 +1,26 @@
+<odoo>
+    <record id="view_product_composition_description_form" model="ir.ui.view">
+        <field name="name">product.composition.description.form</field>
+        <field name="model">product.composition.description</field>
+        <field name="arch" type="xml">
+            <form string="Composition Description">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_product_composition_description_tree" model="ir.ui.view">
+        <field name="name">product.composition.description.tree</field>
+        <field name="model">product.composition.description</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+            </tree>
+        </field>
+    </record>
+</odoo>
+

--- a/product_composition/views/product_composition_menu.xml
+++ b/product_composition/views/product_composition_menu.xml
@@ -1,0 +1,13 @@
+<odoo>
+    <record id="action_product_composition_description" model="ir.actions.act_window">
+        <field name="name">Composition Descriptions</field>
+        <field name="res_model">product.composition.description</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_product_composition_description"
+              name="• Composition Descriptions"
+              parent="product.menu_product_config"
+              action="action_product_composition_description"/>
+</odoo>
+

--- a/product_composition/views/product_composition_views.xml
+++ b/product_composition/views/product_composition_views.xml
@@ -1,0 +1,19 @@
+<odoo>
+    <record id="view_product_template_form_composition" model="ir.ui.view">
+        <field name="name">product.template.form.composition</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_only_form_view"/>
+        <field name="arch" type="xml">
+            <xpath expr="//notebook" position="inside">
+                <page string="Composition">
+                    <field name="composition_line_ids" nolabel="1">
+                        <tree editable="bottom">
+                            <field name="percentage"/>
+                            <field name="description_id" options="{'no_create': True}"/>
+                        </tree>
+                    </field>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- reorder fields so percentage comes before description
- add a bullet in the menu item for composition descriptions

## Testing
- `python3 -m py_compile $(find product_composition -name "*.py" -print)`

------
https://chatgpt.com/codex/tasks/task_e_68414dc1ceb08332a7f66a9ecdfa640d